### PR TITLE
Add check for `error.data` error check.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-oauth2-client ChangeLog
 
+## 3.0.1 - 2021-xx-xx
+
+### Added
+- Added check for `error.data` in error check functions.
+
 ## 3.0.0 - 2021-11-03
 
 ### Removed

--- a/lib/authzHttpClient.js
+++ b/lib/authzHttpClient.js
@@ -75,8 +75,8 @@ async function _handleRequest(target, thisArg, args, oAuth2Client) {
  * @param {Array<*>} options - Method arguments ([url, options]).
  * @param {object} oAuth2Client - Client credentials.
  *
- * @return {Promise} Resolves with the result of re-trying the http method call,
- *   after getting a new access token.
+ * @returns {Promise} Resolves with the result of re-trying the http method
+ *   call, after getting a new access token.
  */
 async function _handleTokenError({
   error, target, thisArg, url, options, oAuth2Client

--- a/lib/authzHttpClient.js
+++ b/lib/authzHttpClient.js
@@ -75,8 +75,8 @@ async function _handleRequest(target, thisArg, args, oAuth2Client) {
  * @param {Array<*>} options - Method arguments ([url, options]).
  * @param {object} oAuth2Client - Client credentials.
  *
- * @returns {Promise} Resolves with the result of re-trying the http method
- *   call, after getting a new access token.
+ * @returns {Promise} Resolves with the result of retrying the http method call,
+ *   after getting a new access token.
  */
 async function _handleTokenError({
   error, target, thisArg, url, options, oAuth2Client

--- a/lib/errorCheck.js
+++ b/lib/errorCheck.js
@@ -12,12 +12,13 @@ export function isInvalidAccessTokenError({error}) {
 }
 
 export function isUnrecoverableError({error}) {
-  return !(error.data.error === 'temporarily_unavailable' ||
+  return !((error.data && error.data.error === 'temporarily_unavailable') ||
     isRecoverableTokenError({error}));
 }
 
 function isRecoverableTokenError({error}) {
   return (
+    error.data &&
     error.data.error === 'invalid_token' &&
     error.data.name === 'ConstraintError'
   );


### PR DESCRIPTION
This was making a the tests in another repo fail with `TypeError: Cannot read property 'error' of undefined`, so I added in a check for `error.data` to the If statements.